### PR TITLE
Added language: danish

### DIFF
--- a/app/scripts/controllers/alt.js
+++ b/app/scripts/controllers/alt.js
@@ -95,6 +95,16 @@ angular.module('wikiDiverApp')
               'resumo d',
               'File:'
             ]
+          },
+          da: {
+            name: 'danish',
+            seeAlso: ['Se også'],
+            stopWords: [
+              'liste af',
+              'Kategori:',
+              'Portal:',
+              'Fil:'
+            ]
           }
         };
         $scope.supportedLanguages = Object.keys(languages).map(function(l){ return languages[l].name; }).sort().join(', ');


### PR DESCRIPTION
Danish added as a supported language, don't think any equivalents of 'disambiguation' and 'outline of' are used on the danish wikipedia.