### PR TITLE
fix: Adds support for Annotated links and section links

### DIFF
--- a/app/scripts/controllers/alt.js
+++ b/app/scripts/controllers/alt.js
@@ -491,7 +491,7 @@ angular.module('wikiDiverApp')
                 // Collect links from the section content
                 var o = linksData.query.pages[Object.keys(linksData.query.pages)[0]].revisions[0]['*'],
                     linksRegex1 = /\[\[(.*?)\]\]/g,
-                    linksRegex2 = /\{\{Annotated link\|(.*?)\}\}/g,
+                    linksRegex2 = /\{\{\s*(?:annotated link|anli?|section link|sec link|slink|§)\s*\|\s*(.*?)\s*\}\}/gi,
                     matches1 = linksRegex1.exec(o),
                     matches2 = linksRegex2.exec(o),
                     links = [];


### PR DESCRIPTION
Hello everyone, 
Firstly, thanks so much for making Seealsology open source—it’s been a pivotal tool for my current research.

While using it, I noticed that for certain article pages some 'See Also' entries were not captured, and in cases of some article pages, Seealsology did not provide any links at all. From what I investigated, the issue seems to be related to how some 'see also' sections of Wikipedia articles are annotated. Specifically, some "See also" include annotated links and/or section links that seemed not to be captured by Seealsology. 

Although this solution may not be exhaustive (as there could be other Wikipedia templates or structures I’ve missed), I’ve found it improves data collection for the pages I manually tested.

Here is a screenshot comparing the results with the current version (left) and my fix (right) for the [Cyberspace wikipedia entry](https://en.wikipedia.org/wiki/Cyberspace):
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/13ce2c8b-3a51-4eab-9db2-ed0a64b8bd45" />

The version with the fix can also be tested under this link: https://nataliastanusch.github.io/strumentalia-seealsology/

Thank you in advance for considering this contribution; I acknowledge that this might be an out of scope fix / a wont fix, but in case it wants to be discussed, I’m happy to have a chat. Cheers!